### PR TITLE
Change rustdoc example to comply with the recommended conventions

### DIFF
--- a/_posts/2012-04-14-how-to-rustdoc.md
+++ b/_posts/2012-04-14-how-to-rustdoc.md
@@ -31,8 +31,8 @@ Rustdocs can be as simple as `Returns a slice` or they can be more involved:
 
     # Arguments
 
-    * byte_start - The byte offset where the slice of `str` starts.
-    * byte_len   - The number of bytes from `str` to use.
+    * `byte_start` - The byte offset where the slice of `str` starts.
+    * `byte_len`   - The number of bytes from `str` to use.
 
     # Safety note
 


### PR DESCRIPTION
Hi, I was reading this blog post and though the initial rustdoc example needed some backticks :)
