### PR TITLE
Fix typo in resume page

### DIFF
--- a/resume.html
+++ b/resume.html
@@ -149,7 +149,7 @@ title: brson's resume
       <h1>Education</h1>
       <div>
         <h2>University of Cincinnati</h2>
-        <h3>B.S. in Computer Science, 20005</h3>
+        <h3>B.S. in Computer Science, 2005</h3>
       </div>
     </section>
 


### PR DESCRIPTION
I guess `20005` should be `2005`. 😸 